### PR TITLE
fix: gitea repo.internal optional in 1.12.5

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   gitea:
-    image: gitea/gitea:latest
+    image: gitea/gitea:1.12.5
     restart: unless-stopped
     volumes:
       - ./data/gitea:/data

--- a/src/server/git-servers/gitea/gitea.ts
+++ b/src/server/git-servers/gitea/gitea.ts
@@ -42,7 +42,7 @@ const $repos = array().items(
     }),
     owner: object({ login: string().required() }),
     private: boolean().required(),
-    internal: boolean().required(),
+    internal: boolean().optional(),
   }),
 );
 


### PR DESCRIPTION
Closes #1 